### PR TITLE
modify relative import

### DIFF
--- a/pycycle/__init__.py
+++ b/pycycle/__init__.py
@@ -1,4 +1,4 @@
-from .cli import cli
+from pycycle.cli import cli
 
 if __name__ == '__main__':
     cli()


### PR DESCRIPTION
modify relative import for `__init__` so that we can execute it directly to test while developing.